### PR TITLE
Prevent overlapping reservations at booking time

### DIFF
--- a/src/main/java/start/spring/io/backend/controller/ReservationController.java
+++ b/src/main/java/start/spring/io/backend/controller/ReservationController.java
@@ -3,6 +3,8 @@ package start.spring.io.backend.controller;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Comparator;
+import java.util.List;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import start.spring.io.backend.dto.ReservationCardView;
 import start.spring.io.backend.model.Facility;
 import start.spring.io.backend.model.Reservation;
 import start.spring.io.backend.model.User;
@@ -36,9 +39,29 @@ public class ReservationController {
     }
 
     @GetMapping
-    public String list(Model model) {
-        model.addAttribute("reservations", service.getAll());
-        model.addAttribute("newReservation", new Reservation());
+    public String list(Model model,
+            @RequestParam(value = "filter", defaultValue = "upcoming") String filter,
+            Authentication authentication) {
+        Integer userId = 1;
+        String userName = "Guest";
+        if (authentication != null && authentication.isAuthenticated()) {
+            User user = userService.getUserByEmail(authentication.getName())
+                    .orElse(null);
+            if (user != null) {
+                userId = user.getUserId();
+                userName = user.getName();
+            }
+        }
+
+        List<ReservationCardView> cards = service.getByUserId(userId).stream()
+                .map(this::toCardView)
+                .filter(card -> filterMatches(card, filter))
+                .sorted(Comparator.comparing(ReservationCardView::startDateTime))
+                .toList();
+
+        model.addAttribute("reservationCards", cards);
+        model.addAttribute("filter", filter);
+        model.addAttribute("userName", userName);
         return "reservation-list";
     }
 
@@ -59,6 +82,7 @@ public class ReservationController {
             @RequestParam("endTime") String endTime,
             @RequestParam("participants") Integer participants,
             @RequestParam(value = "purpose", required = false) String purpose,
+            Model model,
             Authentication authentication) {
         Reservation reservation = new Reservation();
         reservation.setFacilityId(facilityId);
@@ -71,6 +95,16 @@ public class ReservationController {
         reservation.setDate(LocalDateTime.of(date, start));
         reservation.setStartTime(start);
         reservation.setEndTime(end);
+
+        if (service.hasConflict(reservation, null)) {
+            String facilityName = facilityService.getFacilityById(facilityId)
+                    .map(Facility::getName)
+                    .orElse("Selected Facility");
+            model.addAttribute("facilityId", facilityId);
+            model.addAttribute("facilityName", facilityName);
+            model.addAttribute("errorMessage", "That time slot is already booked. Please select another time.");
+            return "reservation-booking";
+        }
 
         Integer userId = 1;
         if (authentication != null && authentication.isAuthenticated()) {
@@ -108,5 +142,64 @@ public class ReservationController {
     public String delete(@PathVariable Integer id) {
         service.delete(id);
         return "redirect:/reservations";
+    }
+
+    private ReservationCardView toCardView(Reservation reservation) {
+        Facility facility = facilityService.getFacilityById(reservation.getFacilityId())
+                .orElse(null);
+
+        String facilityName = facility != null ? facility.getName() : "Facility " + reservation.getFacilityId();
+        String facilityType = facility != null ? facility.getType() : "general";
+
+        String imageUrl = switch (facilityType == null ? "" : facilityType.toLowerCase()) {
+            case "soccer", "football" ->
+                "https://images.unsplash.com/photo-1521412644187-c49fa049e84d?auto=format&fit=crop&w=1000&q=80";
+            case "basketball" ->
+                "https://images.unsplash.com/photo-1546519638-68e109498ffc?auto=format&fit=crop&w=1000&q=80";
+            case "tennis", "padel" ->
+                "https://images.unsplash.com/photo-1508098682722-e99c43a406b2?auto=format&fit=crop&w=1000&q=80";
+            case "badminton" ->
+                "https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&w=1000&q=80";
+            default ->
+                "https://images.unsplash.com/photo-1471295253337-3ceaaedca402?auto=format&fit=crop&w=1000&q=80";
+        };
+
+        String location = switch (facilityType == null ? "" : facilityType.toLowerCase()) {
+            case "tennis", "padel" -> "Racquet Zone";
+            case "basketball" -> "Central Pavilion";
+            case "soccer", "football" -> "North Sports Complex";
+            case "badminton" -> "Indoor Hall";
+            default -> "Main Sports Hub";
+        };
+
+        LocalDateTime startDateTime = reservation.getDate();
+        LocalDateTime endDateTime = LocalDateTime.of(reservation.getDate().toLocalDate(), reservation.getEndTime());
+        boolean isUpcoming = endDateTime.isAfter(LocalDateTime.now());
+        String statusLabel = isUpcoming ? "Upcoming" : "Past";
+        String statusClass = isUpcoming ? "status-upcoming" : "status-past";
+
+        return new ReservationCardView(
+                reservation,
+                facilityName,
+                facilityType,
+                location,
+                imageUrl,
+                statusLabel,
+                statusClass,
+                startDateTime,
+                endDateTime,
+                reservation.getParticipants(),
+                reservation.getPurpose());
+    }
+
+    private boolean filterMatches(ReservationCardView card, String filter) {
+        if ("all".equalsIgnoreCase(filter)) {
+            return true;
+        }
+        boolean isUpcoming = "Upcoming".equalsIgnoreCase(card.statusLabel());
+        if ("past".equalsIgnoreCase(filter)) {
+            return !isUpcoming;
+        }
+        return isUpcoming;
     }
 }

--- a/src/main/java/start/spring/io/backend/dto/ReservationCardView.java
+++ b/src/main/java/start/spring/io/backend/dto/ReservationCardView.java
@@ -1,0 +1,19 @@
+package start.spring.io.backend.dto;
+
+import java.time.LocalDateTime;
+
+import start.spring.io.backend.model.Reservation;
+
+public record ReservationCardView(
+        Reservation reservation,
+        String facilityName,
+        String facilityType,
+        String location,
+        String imageUrl,
+        String statusLabel,
+        String statusClass,
+        LocalDateTime startDateTime,
+        LocalDateTime endDateTime,
+        int participants,
+        String purpose) {
+}

--- a/src/main/java/start/spring/io/backend/repository/ReservationRepository.java
+++ b/src/main/java/start/spring/io/backend/repository/ReservationRepository.java
@@ -1,7 +1,32 @@
 package start.spring.io.backend.repository;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import start.spring.io.backend.model.Reservation;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Integer> {
+    List<Reservation> findByUserId(Integer userId);
+
+    @Query("""
+            select r
+            from Reservation r
+            where r.facilityId = :facilityId
+              and r.date >= :dayStart
+              and r.date < :dayEnd
+              and r.startTime < :endTime
+              and r.endTime > :startTime
+              and (:excludeId is null or r.reservationId <> :excludeId)
+            """)
+    List<Reservation> findConflicts(
+            @Param("facilityId") Integer facilityId,
+            @Param("dayStart") LocalDateTime dayStart,
+            @Param("dayEnd") LocalDateTime dayEnd,
+            @Param("startTime") LocalTime startTime,
+            @Param("endTime") LocalTime endTime,
+            @Param("excludeId") Integer excludeId);
 }

--- a/src/main/java/start/spring/io/backend/service/ReservationService.java
+++ b/src/main/java/start/spring/io/backend/service/ReservationService.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 import start.spring.io.backend.model.Reservation;
 import start.spring.io.backend.repository.ReservationRepository;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,6 +20,25 @@ public class ReservationService {
 
     public List<Reservation> getAll() {
         return repo.findAll();
+    }
+
+    public List<Reservation> getByUserId(Integer userId) {
+        return repo.findByUserId(userId);
+    }
+
+    public boolean hasConflict(Reservation reservation, Integer excludeReservationId) {
+        LocalDateTime startDateTime = reservation.getDate();
+        LocalDateTime dayStart = startDateTime.toLocalDate().atStartOfDay();
+        LocalDateTime dayEnd = dayStart.plusDays(1);
+        LocalTime startTime = reservation.getStartTime();
+        LocalTime endTime = reservation.getEndTime();
+        return !repo.findConflicts(
+                reservation.getFacilityId(),
+                dayStart,
+                dayEnd,
+                startTime,
+                endTime,
+                excludeReservationId).isEmpty();
     }
 
     public Optional<Reservation> getById(Integer id) {

--- a/src/main/resources/templates/reservation-booking.html
+++ b/src/main/resources/templates/reservation-booking.html
@@ -124,6 +124,16 @@
             background: var(--primary-dark);
         }
 
+        .alert {
+            margin: 18px 22px 0;
+            padding: 12px 14px;
+            border-radius: 12px;
+            background: #fef2f2;
+            color: #b91c1c;
+            border: 1px solid #fecaca;
+            font-size: 13px;
+        }
+
         @media (max-width: 520px) {
             .grid-2 {
                 grid-template-columns: 1fr;
@@ -140,6 +150,7 @@
         </div>
         <a class="close" href="/facilities">×</a>
     </div>
+    <div class="alert" th:if="${errorMessage}" th:text="${errorMessage}"></div>
 
     <form th:action="@{/reservations/book}" method="post">
         <input type="hidden" name="facilityId" th:value="${facilityId}" />

--- a/src/main/resources/templates/reservation-list.html
+++ b/src/main/resources/templates/reservation-list.html
@@ -1,138 +1,334 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-  <title>Reservations</title>
-  <style>
-    body { font-family: Arial; margin: 40px; background: #f9f9f9; }
-    h1 { color: #333; margin-bottom: 15px; }
+    <title>My Bookings</title>
+    <style>
+        :root {
+            --bg: #f5f7fb;
+            --card: #ffffff;
+            --text: #0f172a;
+            --muted: #64748b;
+            --primary: #4f46e5;
+            --primary-soft: #eef2ff;
+            --border: #e2e8f0;
+            --upcoming: #22c55e;
+            --past: #94a3b8;
+            --danger: #ef4444;
+        }
 
-    .card {
-      background: #fff;
-      padding: 20px;
-      border-radius: 6px;
-      box-shadow: 0 0 10px rgba(0,0,0,0.1);
-      max-width: 1100px;
-    }
+        * {
+            box-sizing: border-box;
+        }
 
-    table { width: 100%; border-collapse: collapse; margin-top: 10px; }
-    th, td { border: 1px solid #ddd; padding: 12px; text-align: left; }
-    th { background: #4CAF50; color: white; }
-    tr:nth-child(even) { background: #f2f2f2; }
+        body {
+            margin: 0;
+            font-family: "Inter", "Segoe UI", sans-serif;
+            background: var(--bg);
+            color: var(--text);
+        }
 
-    .actions { white-space: nowrap; }
+        header {
+            background: #fff;
+            border-bottom: 1px solid var(--border);
+            padding: 20px 36px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
 
-    a.button, button {
-      padding: 6px 12px;
-      margin: 2px;
-      background: #4CAF50;
-      color: white;
-      text-decoration: none;
-      border: none;
-      border-radius: 4px;
-      cursor: pointer;
-      display: inline-block;
-      font-size: 14px;
-    }
-    a.button.delete { background: #f44336; }
+        .brand {
+            display: flex;
+            align-items: center;
+            gap: 14px;
+        }
 
-    h2 { margin-top: 25px; color: #333; }
+        .brand-icon {
+            width: 44px;
+            height: 44px;
+            border-radius: 14px;
+            background: var(--primary);
+            display: grid;
+            place-items: center;
+            color: white;
+            font-size: 20px;
+            box-shadow: 0 8px 18px rgba(79, 70, 229, 0.24);
+        }
 
-    .form-row {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      align-items: center;
-      margin-top: 10px;
-    }
+        .brand h1 {
+            margin: 0;
+            font-size: 18px;
+        }
 
-    .form-row input, .form-row select {
-      padding: 8px;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      min-width: 140px;
-      box-sizing: border-box;
-    }
+        .brand p {
+            margin: 4px 0 0;
+            color: var(--muted);
+            font-size: 13px;
+        }
 
-    .form-row input[type="number"] { width: 140px; }
-    .form-row input[type="datetime-local"] { min-width: 210px; }
-    .form-row input[type="time"] { width: 140px; }
+        .logout {
+            color: var(--text);
+            text-decoration: none;
+            font-weight: 600;
+        }
 
-    .hint {
-      font-size: 13px;
-      color: #666;
-      margin-top: 8px;
-    }
-  </style>
+        .tabs {
+            background: #fff;
+            border-bottom: 1px solid var(--border);
+            padding: 0 36px;
+        }
+
+        .tabs ul {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            gap: 24px;
+        }
+
+        .tabs a {
+            display: inline-flex;
+            gap: 8px;
+            padding: 14px 0;
+            text-decoration: none;
+            color: var(--muted);
+            font-weight: 600;
+            border-bottom: 2px solid transparent;
+        }
+
+        .tabs a.active {
+            color: var(--primary);
+            border-color: var(--primary);
+        }
+
+        main {
+            padding: 28px 36px 60px;
+        }
+
+        .page-title h2 {
+            margin: 0;
+            font-size: 22px;
+        }
+
+        .page-title p {
+            margin: 6px 0 0;
+            color: var(--muted);
+        }
+
+        .filters {
+            margin-top: 20px;
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+
+        .filter-pill {
+            padding: 8px 16px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: #fff;
+            text-decoration: none;
+            color: var(--text);
+            font-weight: 600;
+            font-size: 13px;
+        }
+
+        .filter-pill.active {
+            background: var(--primary);
+            color: #fff;
+            border-color: transparent;
+            box-shadow: 0 10px 20px rgba(79, 70, 229, 0.2);
+        }
+
+        .cards {
+            margin-top: 24px;
+            display: grid;
+            gap: 18px;
+        }
+
+        .card {
+            background: var(--card);
+            border-radius: 16px;
+            border: 1px solid var(--border);
+            overflow: hidden;
+            display: grid;
+            grid-template-columns: 180px 1fr;
+        }
+
+        .card-image {
+            background-size: cover;
+            background-position: center;
+            position: relative;
+        }
+
+        .status {
+            position: absolute;
+            top: 14px;
+            left: 14px;
+            padding: 4px 12px;
+            border-radius: 999px;
+            font-size: 12px;
+            font-weight: 600;
+            color: #fff;
+            background: var(--upcoming);
+        }
+
+        .status-past {
+            background: var(--past);
+        }
+
+        .card-body {
+            padding: 18px 22px 20px;
+            display: grid;
+            gap: 12px;
+        }
+
+        .card-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+        }
+
+        .card-header h3 {
+            margin: 0;
+            font-size: 18px;
+        }
+
+        .card-header span {
+            color: var(--muted);
+            font-size: 13px;
+        }
+
+        .meta {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 10px 18px;
+            color: var(--muted);
+            font-size: 13px;
+        }
+
+        .meta span {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .btn {
+            padding: 8px 14px;
+            border-radius: 10px;
+            border: 1px solid transparent;
+            text-decoration: none;
+            font-weight: 600;
+            font-size: 13px;
+            text-align: center;
+        }
+
+        .btn-primary {
+            background: var(--primary-soft);
+            color: var(--primary);
+            border-color: transparent;
+        }
+
+        .btn-outline {
+            border-color: var(--border);
+            color: var(--text);
+            background: #fff;
+        }
+
+        .btn-danger {
+            background: #fff;
+            border-color: rgba(239, 68, 68, 0.4);
+            color: var(--danger);
+        }
+
+        .empty-state {
+            margin-top: 30px;
+            padding: 40px;
+            text-align: center;
+            background: #fff;
+            border: 1px dashed var(--border);
+            border-radius: 16px;
+            color: var(--muted);
+        }
+
+        @media (max-width: 860px) {
+            .card {
+                grid-template-columns: 1fr;
+            }
+
+            .card-image {
+                height: 160px;
+            }
+        }
+    </style>
 </head>
-
 <body>
-  <h1>Gestión de Reservations</h1>
+<header>
+    <div class="brand">
+        <div class="brand-icon">📅</div>
+        <div>
+            <h1>Sports Facilities</h1>
+            <p th:text="'Welcome, ' + ${userName}"></p>
+        </div>
+    </div>
+    <a class="logout" href="/logout">↗ Logout</a>
+</header>
 
-  <div class="card">
-    <table>
-      <thead>
-        <tr>
-          <th>ID</th>
-          <th>User</th>
-          <th>Facility</th>
-          <th>Date</th>
-          <th>Start</th>
-          <th>End</th>
-          <th>Participants</th>
-          <th>Purpose</th>
-          <th class="actions">Actions</th>
-        </tr>
-      </thead>
+<nav class="tabs">
+    <ul>
+        <li><a href="/facilities">📅 Available Spaces</a></li>
+        <li><a class="active" href="/reservations">📋 My Bookings</a></li>
+    </ul>
+</nav>
 
-      <tbody>
-        <tr th:each="r : ${reservations}">
-          <td th:text="${r.reservationId}"></td>
-          <td th:text="${r.userId}"></td>
-          <td th:text="${r.facilityId}"></td>
+<main>
+    <div class="page-title">
+        <h2>My Bookings</h2>
+        <p>Manage your bookings and report facility issues.</p>
+    </div>
 
-          <!-- LocalDateTime prints a bit ugly by default; this cleans it up -->
-          <td th:text="${#temporals.format(r.date, 'yyyy-MM-dd HH:mm')}"></td>
+    <div class="filters">
+        <a class="filter-pill" th:classappend="${filter} == 'upcoming' ? ' active' : ''" href="/reservations?filter=upcoming">Upcoming</a>
+        <a class="filter-pill" th:classappend="${filter} == 'past' ? ' active' : ''" href="/reservations?filter=past">Past</a>
+        <a class="filter-pill" th:classappend="${filter} == 'all' ? ' active' : ''" href="/reservations?filter=all">All</a>
+    </div>
 
-          <td th:text="${r.startTime}"></td>
-          <td th:text="${r.endTime}"></td>
-          <td th:text="${r.participants}"></td>
-          <td th:text="${r.purpose}"></td>
+    <div class="cards" th:if="${!#lists.isEmpty(reservationCards)}">
+        <div class="card" th:each="card : ${reservationCards}">
+            <div class="card-image" th:style="|background-image: url('${card.imageUrl}');|">
+                <span class="status" th:classappend="${card.statusClass}" th:text="${card.statusLabel}"></span>
+            </div>
+            <div class="card-body">
+                <div class="card-header">
+                    <div>
+                        <h3 th:text="${card.facilityName}"></h3>
+                    </div>
+                    <span th:text="${card.location}"></span>
+                </div>
+                <div class="meta">
+                    <span>📅 <span th:text="${#temporals.format(card.startDateTime, 'EEEE, MMMM d, yyyy')}"></span></span>
+                    <span>⏰ <span th:text="${#temporals.format(card.startDateTime, 'HH:mm')} + ' - ' + ${#temporals.format(card.endDateTime, 'HH:mm')}"></span></span>
+                    <span>👥 <span th:text="${card.participants} + ' participants'"></span></span>
+                </div>
+                <div class="actions">
+                    <a class="btn btn-primary" th:href="@{/reservations/new/{id}(id=${card.reservation.facilityId})}">Book Again</a>
+                    <a class="btn btn-outline" th:href="@{/maintenance-requests/maintenance-request-form/{id}(id=${card.reservation.facilityId})}">Report Issue</a>
+                    <a class="btn btn-danger" th:href="@{/reservations/delete/{id}(id=${card.reservation.reservationId})}"
+                       onclick="return confirm('Cancel this booking?');">Cancel Booking</a>
+                </div>
+            </div>
+        </div>
+    </div>
 
-          <td class="actions">
-            <a th:href="@{/reservations/edit/{id}(id=${r.reservationId})}" class="button">Editar</a>
-            <a th:href="@{/reservations/delete/{id}(id=${r.reservationId})}"
-               class="button delete"
-               onclick="return confirm('¿Seguro que quieres borrar esta reservation?');">
-              Borrar
-            </a>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    <h2>Añadir Reservation</h2>
-
-    <form th:action="@{/reservations/add}" th:object="${newReservation}" method="post">
-      <div class="form-row">
-        <input type="number" th:field="*{userId}" placeholder="userId" required />
-        <input type="number" th:field="*{facilityId}" placeholder="facilityId" required />
-
-        <!-- If your entity uses LocalDateTime, this input fits nicely -->
-        <input type="datetime-local" th:field="*{date}" required />
-
-        <input type="time" th:field="*{startTime}" required />
-        <input type="time" th:field="*{endTime}" required />
-
-        <input type="number" th:field="*{participants}" placeholder="participants" min="1" required />
-        <input type="text" th:field="*{purpose}" placeholder="purpose" />
-
-        <button type="submit">Añadir</button>
-      </div>
-
-      <div class="hint">
-        Tip: userId y facilityId tienen que existir en la BD, si no, MySQL te dará error por foreign key.
-      </div>
-    </form>
-  </div>
+    <div class="empty-state" th:if="${#lists.isEmpty(reservationCards)}">
+        No bookings found for this view. Try switching the filter or book a new facility.
+    </div>
+</main>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Prevent users from creating bookings that overlap existing reservations for the same facility and day by detecting conflicts at booking time.
- Provide immediate feedback in the booking UI when the selected time slot is unavailable.

### Description
- Added a JPA query `findConflicts` in `ReservationRepository` to locate overlapping reservations for a facility on the same day using `LocalDateTime`/`LocalTime` parameters.
- Implemented `hasConflict` and `getByUserId` in `ReservationService` to compute the day range and check for conflicts via the repository.
- Wired conflict checks into the booking flow in `ReservationController#bookReservation` to return the booking form with an `errorMessage` when a conflict is found, and added `reservationCards` listing and filtering in the `list` endpoint.
- Introduced `ReservationCardView` DTO and updated templates: `reservation-booking.html` shows an error banner (`errorMessage`) on conflicts, and `reservation-list.html` was redesigned to render `reservationCards`, filters, and nicer card UI.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c9c800e08832db5e8bd8712c603c0)