### PR TITLE
Prevent overlapping reservations

### DIFF
--- a/src/main/java/start/spring/io/backend/controller/ReservationController.java
+++ b/src/main/java/start/spring/io/backend/controller/ReservationController.java
@@ -82,6 +82,7 @@ public class ReservationController {
             @RequestParam("endTime") String endTime,
             @RequestParam("participants") Integer participants,
             @RequestParam(value = "purpose", required = false) String purpose,
+            Model model,
             Authentication authentication) {
         Reservation reservation = new Reservation();
         reservation.setFacilityId(facilityId);
@@ -94,6 +95,16 @@ public class ReservationController {
         reservation.setDate(LocalDateTime.of(date, start));
         reservation.setStartTime(start);
         reservation.setEndTime(end);
+
+        if (service.hasOverlap(facilityId, date, start, end)) {
+            String facilityName = facilityService.getFacilityById(facilityId)
+                    .map(Facility::getName)
+                    .orElse("Selected Facility");
+            model.addAttribute("facilityId", facilityId);
+            model.addAttribute("facilityName", facilityName);
+            model.addAttribute("overlapError", "That time slot is already booked. Please choose another time.");
+            return "reservation-booking";
+        }
 
         Integer userId = 1;
         if (authentication != null && authentication.isAuthenticated()) {

--- a/src/main/java/start/spring/io/backend/repository/ReservationRepository.java
+++ b/src/main/java/start/spring/io/backend/repository/ReservationRepository.java
@@ -1,10 +1,13 @@
 package start.spring.io.backend.repository;
 
 import java.util.List;
+import java.time.LocalDateTime;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import start.spring.io.backend.model.Reservation;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Integer> {
     List<Reservation> findByUserId(Integer userId);
+
+    List<Reservation> findByFacilityIdAndDateBetween(Integer facilityId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/start/spring/io/backend/service/ReservationService.java
+++ b/src/main/java/start/spring/io/backend/service/ReservationService.java
@@ -4,6 +4,9 @@ import org.springframework.stereotype.Service;
 import start.spring.io.backend.model.Reservation;
 import start.spring.io.backend.repository.ReservationRepository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,6 +36,13 @@ public class ReservationService {
         return repo.save(r);
     }
 
+    public boolean hasOverlap(Integer facilityId, LocalDate date, LocalTime startTime, LocalTime endTime) {
+        LocalDateTime dayStart = date.atStartOfDay();
+        LocalDateTime dayEnd = date.plusDays(1).atStartOfDay().minusNanos(1);
+        return repo.findByFacilityIdAndDateBetween(facilityId, dayStart, dayEnd).stream()
+                .anyMatch(existing -> timesOverlap(startTime, endTime, existing.getStartTime(), existing.getEndTime()));
+    }
+
     public Optional<Reservation> update(Integer id, Reservation details) {
         return repo.findById(id).map(r -> {
             r.setUserId(details.getUserId());
@@ -48,5 +58,9 @@ public class ReservationService {
 
     public void delete(Integer id) {
         repo.deleteById(id);
+    }
+
+    private boolean timesOverlap(LocalTime start, LocalTime end, LocalTime existingStart, LocalTime existingEnd) {
+        return start.isBefore(existingEnd) && end.isAfter(existingStart);
     }
 }

--- a/src/main/resources/templates/reservation-booking.html
+++ b/src/main/resources/templates/reservation-booking.html
@@ -54,6 +54,15 @@
             font-size: 13px;
         }
 
+        .alert {
+            background: #fff4f4;
+            border: 1px solid #f7c6c6;
+            color: #b42318;
+            border-radius: 12px;
+            padding: 12px 14px;
+            font-size: 13px;
+        }
+
         .close {
             text-decoration: none;
             color: var(--muted);
@@ -143,6 +152,8 @@
 
     <form th:action="@{/reservations/book}" method="post">
         <input type="hidden" name="facilityId" th:value="${facilityId}" />
+
+        <div class="alert" th:if="${overlapError}" th:text="${overlapError}"></div>
 
         <div>
             <label for="bookingDate">Date</label>


### PR DESCRIPTION
### Motivation

- Prevent double-booking of the same facility by disallowing reservation time ranges that overlap an existing booking on the same date.

### Description

- Added `findByFacilityIdAndDateBetween` to `ReservationRepository` to fetch reservations for a facility on a given day.
- Implemented `hasOverlap` and `timesOverlap` in `ReservationService` to detect time-range collisions for a facility on a date.
- Checked for overlaps in `ReservationController.bookReservation` and return the booking form with an `overlapError` model attribute when a conflict is detected.
- Show an inline error message in `reservation-booking.html` and added minimal alert styling to inform the user the selected slot is already booked.

### Testing

- Attempted to run the app with `./mvnw spring-boot:run` but it failed because the Maven wrapper could not download Apache Maven, so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ca86d9754832d84bf280832fa8581)