### PR TITLE
Fix My Bookings rendering: user-based reservations and filter support

### DIFF
--- a/src/main/java/start/spring/io/backend/controller/ReservationController.java
+++ b/src/main/java/start/spring/io/backend/controller/ReservationController.java
@@ -3,6 +3,9 @@ package start.spring.io.backend.controller;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import start.spring.io.backend.dto.ReservationCardView;
 import start.spring.io.backend.model.Facility;
 import start.spring.io.backend.model.Reservation;
 import start.spring.io.backend.model.User;
@@ -36,8 +40,25 @@ public class ReservationController {
     }
 
     @GetMapping
-    public String list(Model model) {
-        model.addAttribute("reservations", service.getAll());
+    public String list(Model model,
+            Authentication authentication,
+            @RequestParam(value = "filter", defaultValue = "upcoming") String filter) {
+        Optional<User> user = getAuthenticatedUser(authentication);
+        Integer userId = user.map(User::getUserId).orElse(null);
+        List<Reservation> reservations = userId == null
+                ? Collections.emptyList()
+                : service.getByUserId(userId);
+        List<ReservationCardView> cards = reservations.stream()
+                .map(this::toCardView)
+                .filter(card -> matchesFilter(card, filter))
+                .toList();
+
+        String userName = user.map(User::getName).orElse("Guest");
+
+        model.addAttribute("reservations", reservations);
+        model.addAttribute("reservationCards", cards);
+        model.addAttribute("filter", filter);
+        model.addAttribute("userName", userName);
         model.addAttribute("currentPage", "reservations");
         model.addAttribute("newReservation", new Reservation());
         return "reservation-list";
@@ -109,5 +130,71 @@ public class ReservationController {
     public String delete(@PathVariable Integer id) {
         service.delete(id);
         return "redirect:/reservations";
+    }
+
+    private Optional<User> getAuthenticatedUser(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return Optional.empty();
+        }
+        return userService.getUserByEmail(authentication.getName());
+    }
+
+    private boolean matchesFilter(ReservationCardView card, String filter) {
+        if ("past".equalsIgnoreCase(filter)) {
+            return "Past".equalsIgnoreCase(card.statusLabel());
+        }
+        if ("all".equalsIgnoreCase(filter)) {
+            return true;
+        }
+        return "Upcoming".equalsIgnoreCase(card.statusLabel());
+    }
+
+    private ReservationCardView toCardView(Reservation reservation) {
+        Facility facility = facilityService.getFacilityById(reservation.getFacilityId()).orElse(null);
+        String facilityName = facility != null ? facility.getName() : "Facility #" + reservation.getFacilityId();
+        String type = facility != null && facility.getType() != null ? facility.getType().toLowerCase() : "";
+
+        String imageUrl = switch (type) {
+            case "tennis", "padel" ->
+                "https://images.unsplash.com/photo-1508609349937-5ec4ae374ebf?auto=format&fit=crop&w=1000&q=80";
+            case "basketball" ->
+                "https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&w=1000&q=80";
+            case "soccer", "football" ->
+                "https://images.unsplash.com/photo-1508098682722-e99c43a406b2?auto=format&fit=crop&w=1000&q=80";
+            case "badminton" ->
+                "https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&w=1000&q=80";
+            default ->
+                "https://images.unsplash.com/photo-1471295253337-3ceaaedca402?auto=format&fit=crop&w=1000&q=80";
+        };
+
+        String location = switch (type) {
+            case "tennis", "padel" -> "Racquet Zone";
+            case "basketball" -> "Central Pavilion";
+            case "soccer", "football" -> "North Sports Complex";
+            case "badminton" -> "Indoor Hall";
+            default -> "Main Sports Hub";
+        };
+
+        LocalDateTime startDateTime = reservation.getDate();
+        LocalDateTime endDateTime = reservation.getDate().with(reservation.getEndTime());
+        boolean isPast = startDateTime.isBefore(LocalDateTime.now());
+        String statusLabel = isPast ? "Past" : "Upcoming";
+        String statusClass = isPast ? "status-past" : "";
+        String purpose = reservation.getPurpose() == null || reservation.getPurpose().isBlank()
+                ? "General Booking"
+                : reservation.getPurpose();
+
+        return new ReservationCardView(
+                reservation,
+                facilityName,
+                facility != null ? facility.getType() : "",
+                location,
+                imageUrl,
+                statusLabel,
+                statusClass,
+                startDateTime,
+                endDateTime,
+                reservation.getParticipants() == null ? 0 : reservation.getParticipants(),
+                purpose);
     }
 }


### PR DESCRIPTION
### Motivation
- The bookings page was showing no entries after a merge because the controller no longer populated the per-user card data and filter state required by the `reservation-list` template.

### Description
- Updated `ReservationController` to load reservations for the authenticated user and expose `reservationCards`, `filter`, and `userName` to the view.
- Built card view data using `ReservationCardView` and added `toCardView`, `matchesFilter`, and `getAuthenticatedUser` helpers to compute image, location, status label/class, and purpose.
- Added request parameter handling for `filter` (supports `upcoming`, `past`, `all`) and wired filtering of card items before rendering.
- Left existing booking create/edit/delete endpoints intact while switching the list endpoint to return user-scoped results to `reservation-list`.

### Testing
- No automated tests were executed as part of this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e1d59597c832da5545761e2aef72a)