### PR TITLE
Enforce reservation overlap checks for facility and user

### DIFF
--- a/src/main/java/start/spring/io/backend/repository/ReservationRepository.java
+++ b/src/main/java/start/spring/io/backend/repository/ReservationRepository.java
@@ -10,4 +10,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Intege
     List<Reservation> findByUserId(Integer userId);
 
     List<Reservation> findByFacilityIdAndDateBetween(Integer facilityId, LocalDateTime start, LocalDateTime end);
+
+    List<Reservation> findByUserIdAndDateBetween(Integer userId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/start/spring/io/backend/service/ReservationService.java
+++ b/src/main/java/start/spring/io/backend/service/ReservationService.java
@@ -43,6 +43,13 @@ public class ReservationService {
                 .anyMatch(existing -> timesOverlap(startTime, endTime, existing.getStartTime(), existing.getEndTime()));
     }
 
+    public boolean hasUserOverlap(Integer userId, LocalDate date, LocalTime startTime, LocalTime endTime) {
+        LocalDateTime dayStart = date.atStartOfDay();
+        LocalDateTime dayEnd = date.plusDays(1).atStartOfDay().minusNanos(1);
+        return repo.findByUserIdAndDateBetween(userId, dayStart, dayEnd).stream()
+                .anyMatch(existing -> timesOverlap(startTime, endTime, existing.getStartTime(), existing.getEndTime()));
+    }
+
     public Optional<Reservation> update(Integer id, Reservation details) {
         return repo.findById(id).map(r -> {
             r.setUserId(details.getUserId());


### PR DESCRIPTION
### Motivation
- Prevent users from booking two facilities at the same time and avoid double-booking the same facility for overlapping time windows.
- Surface clear validation errors on the booking form when the end time is invalid or a conflict exists.
- Add server-side checks because the prior implementation only prevented facility overlaps and allowed a user to have simultaneous bookings.

### Description
- Added `findByUserIdAndDateBetween` to `ReservationRepository` to query a user's reservations on a given day.
- Added `hasUserOverlap` in `ReservationService` which uses `findByUserIdAndDateBetween` and `timesOverlap` to detect user-level conflicts.
- Updated `ReservationController.bookReservation` to accept a `Model`, validate that `endTime` is after `startTime`, check both `service.hasOverlap(...)` for the facility and `service.hasUserOverlap(...)` for the user, and return the booking form with an `overlapError` message when a conflict occurs.
- Added a `bookingError` helper in `ReservationController` to populate the form model and reuse the error rendering path.

### Testing
- No automated tests were executed for this change.
- All changes are limited to repository, service, and controller layers and rely on existing template support for `overlapError` rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e211511a8832da728500c627a3512)