### PR TITLE
Update README with access and login details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# fit-ease-pwr — Backend (Spring Boot + Supabase PostgreSQL)
+# fit-ease-pwr — Web App (Spring Boot + Thymeleaf + Supabase PostgreSQL)
 
 ## What is this?
-- **Spring Boot** = Java backend server (HTTP) → http://localhost:8080  
+- **Spring Boot + Thymeleaf** = Java server-rendered web app → http://localhost:8080  
 - **Supabase PostgreSQL** = cloud database (no Docker needed!)  
 - **Maven Wrapper (`mvnw`)** = run without installing Maven
 
@@ -43,7 +43,18 @@ chmod +x mvnw
 ```
 
 ### 4. Check
-Open: http://localhost:8080/facilities → should show the facilities list if you are logged in.
+Open: http://localhost:8080 → shows a public landing page if you are not logged in.
+
+To access the app, log in at http://localhost:8080/login and then visit
+http://localhost:8080/facilities.
+
+**Default test accounts (created by `DataInitializer`):**
+- Admin: `admin@test.com` / password hash in code
+- User: `user@test.com` / password hash in code
+- Maintenance: `manteinance@test.com` / password hash in code
+- User (Marta): `marta@test.com` / password hash in code
+
+You can also create a new account at http://localhost:8080/signup.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Ensure the README reflects the actual app behavior (server-rendered Thymeleaf web app) and clarifies the landing vs authenticated flow so developers can run and access the app correctly.
- Make onboarding easier by documenting default test accounts created by `DataInitializer` and linking to the signup page.

### Description
- Change README title to describe the project as a Web App: `Spring Boot + Thymeleaf + Supabase PostgreSQL`.
- Replace the short Spring Boot backend line with `Spring Boot + Thymeleaf` and update the quick-check instructions to show the public landing page at `http://localhost:8080` and the login flow at `http://localhost:8080/login` before visiting `http://localhost:8080/facilities`.
- Add a list of default test accounts (Admin: `admin@test.com`, User: `user@test.com`, Maintenance: `manteinance@test.com`, Marta: `marta@test.com`) and a note about creating a new account at `http://localhost:8080/signup`.

### Testing
- Documentation-only change, no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ea253080832db7275b51908f24a1)